### PR TITLE
chore: add pnpm workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+---
+allowBuilds:
+  esbuild: false
+  sharp: false


### PR DESCRIPTION
```
srcery.sh on  master via  v24.11.0 took 2s 
❯ pnpm install
Lockfile is up to date, resolution step is skipped
Packages: +397
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 397, reused 397, downloaded 0, added 397, done

dependencies:
+ @fortawesome/fontawesome-free 7.2.0
+ @srcery-colors/srcery-palette 1.1.0
+ @tailwindcss/vite 4.2.4
+ devicon 2.17.0
+ highlight.js 11.11.1
+ simple-icons 16.18.0
+ tailwindcss 4.2.4

devDependencies:
+ @astrojs/check 0.9.9
+ @biomejs/biome 2.4.14
+ @octokit/types 16.0.0
+ @types/lodash 4.17.24
+ astro 6.2.1
+ lodash 4.18.1
+ octokit 5.0.5
+ prettier 3.8.3
+ prettier-plugin-astro 0.14.1
+ prettier-plugin-packagejson 3.0.2
+ prettier-plugin-tailwindcss 0.8.0
+ typescript 6.0.3

 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.27.7, sharp@0.34.5

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.

srcery.sh on  master [?] via  v24.11.0 took 2s 
❯ pnpm start
Lockfile is up to date, resolution step is skipped
Already up to date
 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.27.7, sharp@0.34.5

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
 ERROR  Command failed with exit code 1: pnpm install

pnpm: Command failed with exit code 1: pnpm install
    at getFinalError (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:28540:14)
    at makeError (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:30847:21)
    at getSyncResult (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:32691:10)
    at spawnSubprocessSync (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:32651:14)
    at execaCoreSync (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:32581:23)
    at callBoundExeca (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:35109:23)
    at boundExeca (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:35086:49)
    at sync (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:35241:14)
    at runPnpmCli (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:208139:5)
    at runDepsStatusCheck (file:///opt/homebrew/Cellar/pnpm/11.0.4/libexec/lib/node_modules/pnpm/dist/pnpm.mjs:209800:7)
```

Not sure if it's kosher to add these to allowed builds.  But, it seems broken without. 🤷🏻‍♂️ And if `false` is also "working".