### PR TITLE
Upgrade palette to v2.0.0 ++

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/src/logo_border.svg">
+  <img src="https://raw.githubusercontent.com/srcery-colors/srcery-assets/master/logo/logo.svg">
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
     "@srcery-colors/srcery-palette": "^2.0.0",
-    "@tailwindcss/vite": "^4.2.4",
     "devicon": "^2.17.0",
     "highlight.js": "^11.11.1",
     "simple-icons": "^16.18.0",
@@ -48,6 +47,7 @@
     "@astrojs/check": "0.9.9",
     "@biomejs/biome": "2.4.14",
     "@octokit/types": "16.0.0",
+    "@tailwindcss/vite": "^4.2.4",
     "@types/lodash": "4.17.24",
     "astro": "6.2.2",
     "lodash": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
-    "@srcery-colors/srcery-palette": "^1.1.0",
+    "@srcery-colors/srcery-palette": "^2.0.0",
     "@tailwindcss/vite": "^4.2.4",
     "devicon": "^2.17.0",
     "highlight.js": "^11.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       '@srcery-colors/srcery-palette':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4))
@@ -837,8 +837,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@srcery-colors/srcery-palette@1.1.0':
-    resolution: {integrity: sha512-NBYEoTm1A7OMyfF8M88PMfR3g7DhilDFC3KK/ysI1qUSioGTrMNju7iXpzZu0mOsMq15/iXIvl/4SR9jkSEVHw==}
+  '@srcery-colors/srcery-palette@2.0.0':
+    resolution: {integrity: sha512-zHA3+qSa9gwkaulNNCKE49dqQnxfDIHoHG3Ij3prRtVkQZqIjoGWxKZdjEIPuiy6yyTXoSRv5iq9UxqhrEwQlw==}
 
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
@@ -2951,7 +2951,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@srcery-colors/srcery-palette@1.1.0': {}
+  '@srcery-colors/srcery-palette@2.0.0': {}
 
   '@tailwindcss/node@4.2.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@srcery-colors/srcery-palette':
         specifier: ^2.0.0
         version: 2.0.0
-      '@tailwindcss/vite':
-        specifier: ^4.2.4
-        version: 4.2.4(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4))
       devicon:
         specifier: ^2.17.0
         version: 2.17.0
@@ -39,6 +36,9 @@ importers:
       '@octokit/types':
         specifier: 16.0.0
         version: 16.0.0
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.4))
       '@types/lodash':
         specifier: 4.17.24
         version: 4.17.24

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -9,7 +9,7 @@ const { url } = Astro.props;
 <a
   href={url}
   target="_blank"
-  class="inline-block text-[11px] tracking-[2px] uppercase no-underline py-1.5 px-4 border text-center text-white transition-[color,border-color,background-color] duration-200 relative text-bright-white border-bright-black hover:border-bright-white hover:text-bright-white"
+  class="inline-block text-[11px] tracking-[2px] uppercase no-underline py-1.5 px-4 border text-center text-white transition-[color,border-color,background-color] duration-200 relative text-bright-white border-bright-black hover:border-white hover:text-bright-white hover:bg-gray1"
 >
   <slot />
   <!-- <img -->

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,7 @@
 ---
 
 <footer
-  class="w-full border-t border-xgray3 p-4 mt-6 text-bright-black text-xs"
+  class="w-full border-t border-gray2 p-4 mt-6 text-bright-black text-xs"
 >
   <p class="text-center pb-1">
     Made with

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -42,15 +42,15 @@ const { activePage } = Astro.props;
     </div>
     <div class="mt-4 flex items-center sm:mt-[-18%]">
       <div class="mr-2 flex">
-        <div class="dot bg-xgray2"></div>
-        <div class="dot bg-xgray7"></div>
-        <div class="dot bg-xgray10"></div>
+        <div class="dot bg-gray2"></div>
+        <div class="dot bg-gray3"></div>
+        <div class="dot bg-gray4"></div>
       </div>
       <h1 class="text-6xl uppercase">Srcery</h1>
       <div class="ml-2 flex">
-        <div class="dot bg-xgray10"></div>
-        <div class="dot bg-xgray7"></div>
-        <div class="dot bg-xgray2"></div>
+        <div class="dot bg-gray4"></div>
+        <div class="dot bg-gray3"></div>
+        <div class="dot bg-gray2"></div>
       </div>
     </div>
   </a>

--- a/src/components/MemberCard.astro
+++ b/src/components/MemberCard.astro
@@ -20,7 +20,7 @@ const { name, avatarUrl, url, member = false } = Astro.props;
       >
         {
           member ? (
-            <div class="absolute -inset-[10px] rounded-full border border-dashed border-gray6 [animation:spin_20s_linear_infinite] transition-[opacity,inset] duration-300 ease group-hover:border-bright-black group-hover:-inset-[13px] group-hover:rotate-45" />
+            <div class="absolute -inset-[10px] rounded-full border border-dashed border-gray6 [animation:spin_50s_linear_infinite] transition-[opacity,inset] duration-300 ease group-hover:border-bright-black group-hover:-inset-[13px]" />
           ) : null
         }
         <div

--- a/src/components/MemberCard.astro
+++ b/src/components/MemberCard.astro
@@ -20,7 +20,7 @@ const { name, avatarUrl, url, member = false } = Astro.props;
       >
         {
           member ? (
-            <div class="absolute -inset-[10px] rounded-full border border-dashed border-xgray5 [animation:spin_20s_linear_infinite] transition-[opacity,inset] duration-300 ease group-hover:border-bright-black group-hover:-inset-[13px] group-hover:rotate-45" />
+            <div class="absolute -inset-[10px] rounded-full border border-dashed border-gray6 [animation:spin_20s_linear_infinite] transition-[opacity,inset] duration-300 ease group-hover:border-bright-black group-hover:-inset-[13px] group-hover:rotate-45" />
           ) : null
         }
         <div

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -40,7 +40,7 @@ const contributors = sortBy(github.contributors, ["contributions"]).reverse();
           <div>
             <Button url="https://discord.gg/G6vBMmZ">
               <div class="flex">
-                <Discord class="fill-bright-white mr-4" width="16px" />
+                <Discord class="fill-white mr-4" width="16px" />
                 Go to Discord
               </div>
             </Button>
@@ -58,7 +58,7 @@ const contributors = sortBy(github.contributors, ["contributions"]).reverse();
           <div class="">
             <Button url="https://srcery-colors.creator-spring.com">
               <div class="flex">
-                <Spring class="fill-bright-white mr-4" width="16px" />
+                <Spring class="fill-white mr-4" width="16px" />
                 Go to the store
               </div>
             </Button>

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -89,14 +89,14 @@ try {
             install the package using npm or git:
           </p>
           <div class="flex flex-col gap-2">
-            <div class="bg-hard-black p-2 overflow-x-auto">
+            <div class="bg-gray1 p-2 overflow-x-auto">
               <Code
                 language="bash"
                 code="npm i @srcery-colors/srcery-palette"
               />
             </div>
 
-            <div class="bg-hard-black p-2 overflow-x-auto">
+            <div class="bg-gray1 p-2 overflow-x-auto">
               <Code
                 language="bash"
                 code="git clone https://github.com/srcery-colors/srcery-palette"
@@ -112,7 +112,7 @@ try {
             <code class="inline-code">json</code> palette in <code
               class="inline-code">bash</code
             >:
-            <div class="bg-hard-black p-2 overflow-x-auto">
+            <div class="bg-gray1 p-2 overflow-x-auto">
               <Code
                 language="bash"
                 code="jq < palette.json '.primary.red.hex'"
@@ -124,7 +124,7 @@ try {
               in javascript like this:
             </span>
 
-            <div class="bg-hard-black p-2 overflow-x-auto">
+            <div class="bg-gray1 p-2 overflow-x-auto">
               <Code language="js" code={jsImportCode} />
             </div>
 
@@ -133,7 +133,7 @@ try {
               your CSS files
             </span>
 
-            <div class="bg-hard-black p-2 overflow-x-auto">
+            <div class="bg-gray1 p-2 overflow-x-auto">
               <Code language="css" code={cssImportCode} />
             </div>
           </p>

--- a/src/pages/themes/index.astro
+++ b/src/pages/themes/index.astro
@@ -253,14 +253,14 @@ const themes = [
                   <a
                     href={theme.repo}
                     target="_blank"
-                    class="text-[11px] tracking-[2px] uppercase no-underline py-1.5 px-4 border border-transparent w-full text-center text-white transition-[color,border-color,background-color] duration-200 relative hover:text-bright-white hover:border-bright-black hover:bg-xgray1"
+                    class="text-[11px] tracking-[2px] uppercase no-underline py-1.5 px-4 border border-transparent w-full text-center text-white transition-[color,border-color,background-color] duration-200 relative hover:text-bright-white hover:border-bright-black hover:bg-gray1"
                   >
                     repository
                   </a>
                   <a
                     href={theme.download}
                     target="_blank"
-                    class="text-[11px] tracking-[2px] uppercase no-underline py-1.5 px-4 border border-transparent w-full text-center text-white transition-[color,border-color,background-color] duration-200 relative hover:text-bright-white hover:border-bright-black hover:bg-xgray1"
+                    class="text-[11px] tracking-[2px] uppercase no-underline py-1.5 px-4 border border-transparent w-full text-center text-white transition-[color,border-color,background-color] duration-200 relative hover:text-bright-white hover:border-bright-black hover:bg-gray1"
                   >
                     download
                   </a>

--- a/src/style.css
+++ b/src/style.css
@@ -71,7 +71,7 @@
 }
 
 @utility tab-inactive {
-  @apply border-b-1 hover:bg-gray1;
+  @apply border-b-1 hover:bg-gray1 hover:cursor-pointer;
 }
 
 @utility tab-active {

--- a/src/style.css
+++ b/src/style.css
@@ -6,41 +6,31 @@
     Iosevka Custom Web, ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
-  --color-black: var(--srcery-palette-primary-black);
-  --color-red: var(--srcery-palette-primary-red);
-  --color-green: var(--srcery-palette-primary-green);
-  --color-yellow: var(--srcery-palette-primary-yellow);
-  --color-blue: var(--srcery-palette-primary-blue);
-  --color-magenta: var(--srcery-palette-primary-magenta);
-  --color-cyan: var(--srcery-palette-primary-cyan);
-  --color-white: var(--srcery-palette-primary-white);
-  --color-bright-black: var(--srcery-palette-primary-bright-black);
-  --color-bright-red: var(--srcery-palette-primary-bright-red);
-  --color-bright-green: var(--srcery-palette-primary-bright-green);
-  --color-bright-yellow: var(--srcery-palette-primary-bright-yellow);
-  --color-bright-blue: var(--srcery-palette-primary-bright-blue);
-  --color-bright-magenta: var(--srcery-palette-primary-bright-magenta);
-  --color-bright-cyan: var(--srcery-palette-primary-bright-cyan);
-  --color-bright-white: var(--srcery-palette-primary-bright-white);
+  --color-black: var(--srcery-palette-black);
+  --color-red: var(--srcery-palette-red);
+  --color-green: var(--srcery-palette-green);
+  --color-yellow: var(--srcery-palette-yellow);
+  --color-blue: var(--srcery-palette-blue);
+  --color-magenta: var(--srcery-palette-magenta);
+  --color-cyan: var(--srcery-palette-cyan);
+  --color-white: var(--srcery-palette-white);
+  --color-bright-black: var(--srcery-palette-bright-black);
+  --color-bright-red: var(--srcery-palette-bright-red);
+  --color-bright-green: var(--srcery-palette-bright-green);
+  --color-bright-yellow: var(--srcery-palette-bright-yellow);
+  --color-bright-blue: var(--srcery-palette-bright-blue);
+  --color-bright-magenta: var(--srcery-palette-bright-magenta);
+  --color-bright-cyan: var(--srcery-palette-bright-cyan);
+  --color-bright-white: var(--srcery-palette-bright-white);
   --color-orange: var(--srcery-palette-secondary-orange);
   --color-bright-orange: var(--srcery-palette-secondary-bright-orange);
-  --color-hard-black: var(--srcery-palette-secondary-hard-black);
   --color-teal: var(--srcery-palette-secondary-teal);
-  --color-xgray1: var(--srcery-palette-secondary-xgray1);
-  --color-xgray2: var(--srcery-palette-secondary-xgray2);
-  --color-xgray3: var(--srcery-palette-secondary-xgray3);
-  --color-xgray4: var(--srcery-palette-secondary-xgray4);
-  --color-xgray5: var(--srcery-palette-secondary-xgray5);
-  --color-xgray6: var(--srcery-palette-secondary-xgray6);
-  --color-xgray7: var(--srcery-palette-secondary-xgray7);
-  --color-xgray8: var(--srcery-palette-secondary-xgray8);
-  --color-xgray9: var(--srcery-palette-secondary-xgray9);
-  --color-xgray10: var(--srcery-palette-secondary-xgray10);
-  --color-xgray11: var(--srcery-palette-secondary-xgray11);
-  --color-xgray12: var(--srcery-palette-secondary-xgray12);
-
-  /* until we move to the next palette, I need this darker gray */
-  --color-gray2: #202020;
+  --color-gray1: var(--srcery-palette-gray1);
+  --color-gray2: var(--srcery-palette-gray2);
+  --color-gray3: var(--srcery-palette-gray3);
+  --color-gray4: var(--srcery-palette-gray4);
+  --color-gray5: var(--srcery-palette-gray5);
+  --color-gray6: var(--srcery-palette-gray6);
 
   --breakpoint-tiny: 320px;
 
@@ -81,7 +71,7 @@
 }
 
 @utility tab-inactive {
-  @apply border-b-1 hover:bg-xgray1;
+  @apply border-b-1 hover:bg-gray1;
 }
 
 @utility tab-active {
@@ -95,11 +85,11 @@
 }
 
 @utility code {
-  @apply mb-3 flex overflow-x-auto bg-hard-black p-4 whitespace-nowrap;
+  @apply mb-3 flex overflow-x-auto bg-gray1 p-4 whitespace-nowrap;
 }
 
 @utility inline-code {
-  @apply bg-hard-black p-1 whitespace-nowrap;
+  @apply bg-gray1 p-1 whitespace-nowrap;
 }
 
 @utility list-dot {


### PR DESCRIPTION
# Upgrade palette to v2.0.0 ++

Upgraded the palette, there were a few changes that had to be made, but mostly just search and replace. Most notably I think is the codeblocks:
<img width="1602" height="842" alt="image" src="https://github.com/user-attachments/assets/52d5727b-d3c3-4df4-a09b-144b9f58aba7" />

hard_black is no longer, gray1 is the previous background, and works really well for codeblock.

Closes #1139

## Additional changes

I included a few minor fixes as well:
- [x] Use cursor-pointer on main page when hovering inactive tabs
- [x] Improve button consistency by matching hover background color.
- [x] Increase core member animation duration for the spinning border, was a bit to fast IMO
- [x] I replaced the logo in readme with the latest one. 
- [x] The glyph on the webpage was already using 2.0.0 colors, I cleaned up the svg, added attribution and licensing information, and also updated the colors a in the astro pr #1125, just slipped my mind.
- [x] (deps) move `@tailwindcss/vite` to dev dependencies